### PR TITLE
Edit readme - Add dependencies needed to compile a release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+version: 0.08.1
+date: Mon Jul 30 23:05:04 CEST 2018
+changes:
+	- move some functionality to isl
+---
 version: 0.08
 date: Sat Mar  3 15:31:38 CET 2018
 changes:

--- a/README
+++ b/README
@@ -11,10 +11,12 @@ Requirements:
 	Unless you have some other reasons for wanting to use the svn version,
 	it is best to install the latest release (3.9).
 	For more details, see pet/README.
+- zlib (https://zlib.net)
+	Compression library - Needed to compile PPCG.
 
 If you are installing on Ubuntu, then you can install the following packages:
 
-automake autoconf libtool pkg-config libgmp3-dev libyaml-dev libclang-dev llvm
+automake autoconf libtool pkg-config libgmp3-dev libyaml-dev libclang-dev llvm zlib1g-dev
 
 Note that you need at least version 3.2 of libclang-dev (ubuntu raring).
 Older versions of this package did not include the required libraries.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([ppcg], [0.08], [isl-development@googlegroups.com])
+AC_INIT([ppcg], [0.08.1], [isl-development@googlegroups.com])
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign])


### PR DESCRIPTION
Add dependency on readme needed to compile ppcg. Without this dependency is not possible to extract all files needed when running make.